### PR TITLE
Refactored Models and Admin Route Functions into separate files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module moonlightfight.com/elo-backend
+module github.com/moonlightfight/elo-backend
 
 go 1.16
 

--- a/models/models.go
+++ b/models/models.go
@@ -1,0 +1,17 @@
+package models
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type Admin struct {
+	ID       primitive.ObjectID `json:"_id,omitempty" bson:"_id,omitempty"`
+	Email    string             `json:"email,omitempty" bson:"email,omitempty"`
+	Username string             `json:"username,omitempty" bson:"username,omitempty"`
+	Password string             `json:"password,omitempty" bson:"password,omitempty"`
+}
+
+type LoginData struct {
+	Email    string `json:"email" bson:"email"`
+	Password string `json:"password" bson:"password"`
+}

--- a/routes/admin/admin.go
+++ b/routes/admin/admin.go
@@ -1,0 +1,122 @@
+package admin
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	c "github.com/moonlightfight/elo-backend/config"
+	m "github.com/moonlightfight/elo-backend/models"
+	"github.com/spf13/viper"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"golang.org/x/crypto/bcrypt"
+)
+
+var client *mongo.Client
+
+func DoPasswordsMatch(hashedPassword, inputPassword string) bool {
+	err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(inputPassword))
+	return err != nil
+}
+
+func HashPassword(password string) string {
+	var passwordBytes = []byte(password)
+	hashedPasswordBytes, err := bcrypt.GenerateFromPassword(passwordBytes, bcrypt.MinCost)
+
+	if err != nil {
+		log.Println(err)
+	}
+
+	var base64PasswordHash = base64.URLEncoding.EncodeToString(hashedPasswordBytes)
+
+	return base64PasswordHash
+}
+
+func CreateAdminEndpoint(response http.ResponseWriter, request *http.Request) {
+	response.Header().Set("content-type", "application/json")
+	var admin m.Admin
+	_ = json.NewDecoder(request.Body).Decode(&admin)
+	// encrypt user password
+	admin.Password = HashPassword(admin.Password)
+	collection := client.Database("").Collection("Admin")
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	result, _ := collection.InsertOne(ctx, admin)
+	json.NewEncoder(response).Encode(result)
+}
+
+func AdminLoginEndpoint(response http.ResponseWriter, request *http.Request) {
+	// Set the file name of the configurations file
+	viper.SetConfigName("config")
+
+	// Set the path to look for the configurations file
+	viper.AddConfigPath(".")
+
+	// Enable VIPER to read Environment Variables
+	viper.AutomaticEnv()
+
+	viper.SetConfigType("yml")
+	var configuration c.Configurations
+
+	if err := viper.ReadInConfig(); err != nil {
+		fmt.Printf("Error reading config file, %s", err)
+	}
+
+	err := viper.Unmarshal(&configuration)
+	if err != nil {
+		fmt.Printf("Unable to decode into struct, %v", err)
+	}
+	response.Header().Set("content-type", "application/json")
+	var loginData m.LoginData
+	// retrieve request args
+	_ = json.NewDecoder(request.Body).Decode(&loginData)
+	var user m.Admin
+	// retrieve user if exists
+	collection := client.Database("").Collection("Admin")
+	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	dbErr := collection.FindOne(ctx, m.Admin{Email: loginData.Email}).Decode(&user)
+	if dbErr != nil {
+		response.WriteHeader(http.StatusInternalServerError)
+		response.Write([]byte(`{ "message": "` + err.Error() + `" }`))
+		return
+	}
+	// check if passwords match with bcrypt
+	passwordsMatch := DoPasswordsMatch(user.Password, loginData.Password)
+	if !passwordsMatch {
+		response.WriteHeader(http.StatusNotAcceptable)
+		response.Write([]byte(`{ "message": "Invalid Password"}`))
+		return
+	}
+	// generate jwt
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
+		"username": user.Username,
+		"email":    user.Email,
+		"_id":      user.ID,
+		"iat":      time.Now().Unix(),
+	})
+	tokenString, tokenErr := token.SignedString([]byte(configuration.Server.Secret))
+	if tokenErr != nil {
+		response.WriteHeader(http.StatusInternalServerError)
+		io.WriteString(response, `{"error":"token_generation_failed"}`)
+		return
+	}
+	// format response data
+	type ResData struct {
+		ID    primitive.ObjectID `json:"_id,omitempty" bson:"_id,omitempty"`
+		token string             `json:"token,omitempty" bson:"token,omitempty"`
+	}
+
+	resData := ResData{
+		ID:    user.ID,
+		token: tokenString,
+	}
+
+	// return data
+	json.NewEncoder(response).Encode(resData)
+}

--- a/server.go
+++ b/server.go
@@ -2,126 +2,19 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"io"
-	"log"
 	"net/http"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/mux"
 	c "github.com/moonlightfight/elo-backend/config"
-	m "github.com/moonlightfight/elo-backend/models"
+	a "github.com/moonlightfight/elo-backend/routes/admin"
 	"github.com/spf13/viper"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"golang.org/x/crypto/bcrypt"
 )
 
 var client *mongo.Client
-
-func CreateAdminEndpoint(response http.ResponseWriter, request *http.Request) {
-	response.Header().Set("content-type", "application/json")
-	var admin m.Admin
-	_ = json.NewDecoder(request.Body).Decode(&admin)
-	// encrypt user password
-	admin.Password = HashPassword(admin.Password)
-	collection := client.Database("").Collection("Admin")
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
-	result, _ := collection.InsertOne(ctx, admin)
-	json.NewEncoder(response).Encode(result)
-}
-
-func AdminLoginEndpoint(response http.ResponseWriter, request *http.Request) {
-	// Set the file name of the configurations file
-	viper.SetConfigName("config")
-
-	// Set the path to look for the configurations file
-	viper.AddConfigPath(".")
-
-	// Enable VIPER to read Environment Variables
-	viper.AutomaticEnv()
-
-	viper.SetConfigType("yml")
-	var configuration c.Configurations
-
-	if err := viper.ReadInConfig(); err != nil {
-		fmt.Printf("Error reading config file, %s", err)
-	}
-
-	err := viper.Unmarshal(&configuration)
-	if err != nil {
-		fmt.Printf("Unable to decode into struct, %v", err)
-	}
-	response.Header().Set("content-type", "application/json")
-	var loginData m.LoginData
-	// retrieve request args
-	_ = json.NewDecoder(request.Body).Decode(&loginData)
-	var user m.Admin
-	// retrieve user if exists
-	collection := client.Database("").Collection("Admin")
-	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
-	dbErr := collection.FindOne(ctx, m.Admin{Email: loginData.Email}).Decode(&user)
-	if dbErr != nil {
-		response.WriteHeader(http.StatusInternalServerError)
-		response.Write([]byte(`{ "message": "` + err.Error() + `" }`))
-		return
-	}
-	// check if passwords match with bcrypt
-	passwordsMatch := DoPasswordsMatch(user.Password, loginData.Password)
-	if !passwordsMatch {
-		response.WriteHeader(http.StatusNotAcceptable)
-		response.Write([]byte(`{ "message": "Invalid Password"}`))
-		return
-	}
-	// generate jwt
-	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
-		"username": user.Username,
-		"email":    user.Email,
-		"_id":      user.ID,
-		"iat":      time.Now().Unix(),
-	})
-	tokenString, tokenErr := token.SignedString([]byte(configuration.Server.Secret))
-	if tokenErr != nil {
-		response.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(response, `{"error":"token_generation_failed"}`)
-		return
-	}
-	// format response data
-	type ResData struct {
-		ID    primitive.ObjectID `json:"_id,omitempty" bson:"_id,omitempty"`
-		token string             `json:"token,omitempty" bson:"token,omitempty"`
-	}
-
-	resData := ResData{
-		ID:    user.ID,
-		token: tokenString,
-	}
-
-	// return data
-	json.NewEncoder(response).Encode(resData)
-}
-
-func DoPasswordsMatch(hashedPassword, inputPassword string) bool {
-	err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(inputPassword))
-	return err != nil
-}
-
-func HashPassword(password string) string {
-	var passwordBytes = []byte(password)
-	hashedPasswordBytes, err := bcrypt.GenerateFromPassword(passwordBytes, bcrypt.MinCost)
-
-	if err != nil {
-		log.Println(err)
-	}
-
-	var base64PasswordHash = base64.URLEncoding.EncodeToString(hashedPasswordBytes)
-
-	return base64PasswordHash
-}
 
 func main() {
 	// Set the file name of the configurations file
@@ -150,7 +43,7 @@ func main() {
 	port := fmt.Sprintf(":%d", configuration.Server.Port)
 	mongo.Connect(ctx, clientOptions)
 	router := mux.NewRouter()
-	router.HandleFunc("/api/admin", CreateAdminEndpoint).Methods("POST")
-	router.HandleFunc("/api/admin/login", AdminLoginEndpoint).Methods("POST")
+	router.HandleFunc("/api/admin", a.CreateAdminEndpoint).Methods("POST")
+	router.HandleFunc("/api/admin/login", a.AdminLoginEndpoint).Methods("POST")
 	http.ListenAndServe(port, router)
 }


### PR DESCRIPTION
- All MongoDB models and related/reusable types should go into /models/model.go
- All endpoint functions should be put into their own submodule in the /routes directory (e.g. `player` routes should be `/routes/player/player.go`